### PR TITLE
8314498: [macos] Transferring File objects to Finder fails

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CClipboard.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CClipboard.java
@@ -89,7 +89,11 @@ final class CClipboard extends SunClipboard {
 
             try {
                 byte[] bytes = DataTransferer.getInstance().translateTransferable(contents, flavor, format);
-                setData(bytes, format);
+                if (DataFlavor.javaFileListFlavor.equals(flavor)) {
+                    writeObjects(bytes);
+                } else {
+                    setData(bytes, format);
+                }
             } catch (IOException e) {
                 // Fix 4696186: don't print exception if data with
                 // javaJVMLocalObjectMimeType failed to serialize.
@@ -127,6 +131,7 @@ final class CClipboard extends SunClipboard {
 
     private native void declareTypes(long[] formats, SunClipboard newOwner);
     private native void setData(byte[] data, long format);
+    private native void writeObjects(byte[] data);
 
     void checkPasteboardAndNotify() {
         if (checkPasteboardWithoutNotification()) {


### PR DESCRIPTION
Credit goes to JetBrain that fixed it in JetBrainsRuntime (commit 24819d9). This fix was also cherry-picked to muCommander and was verified on macOS 12.6.8 and macOs 13, on X86_64 and on M1.